### PR TITLE
chore/bump go version to 1.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ permissions:
 env:
   # Go language version to use for building. This value should also be updated
   # in the release workflow if changed.
-  GO_VERSION: '1.18'
+  GO_VERSION: '1.19'
 
 jobs:
   # Ensure project builds before running testing matrix

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Flagsmith/terraform-provider-flagsmith
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Flagsmith/flagsmith-go-api-client v0.6.0


### PR DESCRIPTION
Update the go version to 1.19 as per the go support policy https://go.dev/doc/devel/release#policy