### PR TITLE
144: Accept empty string values in feature state resources

### DIFF
--- a/flagsmith/resource_feature_state.go
+++ b/flagsmith/resource_feature_state.go
@@ -97,8 +97,9 @@ func (t *featureStateResource) Schema(ctx context.Context, req resource.SchemaRe
 						Optional:            true,
 						Validators: []validator.String{
 							// Validate string value satisfies the regular expression for no leading or trailing whitespace
+							// but allow empty string
 							stringvalidator.RegexMatches(
-								regexp.MustCompile(`^\S[\s\S]*\S$`),
+								regexp.MustCompile(`^\S[\s\S]*\S$|^$`),
 								"Leading and trailing whitespace is not allowed",
 							),
 						},

--- a/flagsmith/resource_feature_state_test.go
+++ b/flagsmith/resource_feature_state_test.go
@@ -27,7 +27,11 @@ func TestAccEnvironmentFeatureStateResource(t *testing.T) {
 				Config:      testAccEnvironmentFeatureStateResourceConfig(" some_value ", true),
 				ExpectError: regexp.MustCompile(`Attribute feature_state_value.string_value Leading and trailing whitespace is\n.*not allowed`),
 			},
-
+			// Ensure that empty strings pass validation
+			{
+				Config:      testAccEnvironmentFeatureStateResourceConfig("", true),
+				ExpectError: nil,
+			},
 			// Create and Read testing
 			{
 				Config: testAccEnvironmentFeatureStateResourceConfig("one", true),


### PR DESCRIPTION
From #144: White space validation needs to continue to allow empty strings to be accepted by feature state resources.