### PR TITLE
fix: Update .goreleaser.yml to v2 format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:
@@ -29,7 +30,8 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats:
+    - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
@@ -56,4 +58,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## Summary
- Add `version: 2` to `.goreleaser.yml` (required by goreleaser v2)
- Replace deprecated `changelog.skip: true` with `changelog.disable: true`
- Replace deprecated `archives.format` with `archives.formats` list

Verified locally with `goreleaser check` and `goreleaser release --clean --snapshot --skip=publish,sign` — builds all platforms successfully.

Fixes the release failure after the goreleaser-action v5→v7 bump (#207).