### PR TITLE
fix(ci): Install Terraform in `generate` step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   # Ensure project builds before running testing matrix
   build:
-    if: github.event.pull_request.draft == true
+    if: github.event.pull_request.draft == false
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -32,7 +32,7 @@ jobs:
       - run: go build -v .
 
   generate:
-    if: github.event.pull_request.draft == true
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v4
       - run: go generate ./...
       - name: git diff
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   # Ensure project builds before running testing matrix
   build:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == true
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -32,7 +32,7 @@ jobs:
       - run: go build -v .
 
   generate:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The doc-generation job was downloading its own Terraform binary and failing on an expired signing key.
Installing Terraform first avoids the download.

Closes #234 